### PR TITLE
Automatically terminate when pinger goroutine fails

### DIFF
--- a/ping/ping.go
+++ b/ping/ping.go
@@ -98,7 +98,7 @@ pingloop:
 			}
 		case <-p.Done():
 			if err := p.Err(); err != nil {
-				return errors.New("Can't start pinger")
+				return fmt.Errorf("Can't start pinger: %s", err)
 			}
 			break pingloop
 		}


### PR DESCRIPTION
Hi - I've spent some time trying to use graphping and been debugging it for a while (also trying to refresh my limited knowledge of Go).

Basically, I got graphping running, but it wasn't sending any data to statsd. I eventually got this error printed out which indicated why pinging wasn't working: "listen ip4:icmp : socket: operation not permitted"

However, that message wasn't logged, so it wasn't obvious that there was a probblem. Also, graphping itself stayed running, even though the pinger goroutines had ceased execution - so it gave the impression that it was active, even though all that graphping was doing waiting for a keyboard interrupt to terminate it.

I've made changes such that any error message in the pinger which causes it to fail will be returned to graphping; graphping will log that message, and then cause graphping itself to terminate.