### PR TITLE
Bugfix: creating multiple pingers and statsd prefixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/cactus/go-statsd-client/statsd"
-	"github.com/jaxxstorm/graphping/config"
+	configpkg "github.com/jaxxstorm/graphping/config"
 	"github.com/jaxxstorm/graphping/ping"
 	"gopkg.in/urfave/cli.v1"
 	"os"
@@ -61,7 +61,7 @@ func main() {
 		}
 
 		// if we can't parse it, error
-		config, err := config.Parse(c.String("config-file"))
+		config, err := configpkg.Parse(c.String("config-file"))
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("Error: Unable to parse config file - %s", err), -1)
 		} else {
@@ -85,11 +85,11 @@ func main() {
 			// loop through the groups and start a goroutine
 			// for each group to ping the targets
 			for _, groups := range config.Groups {
-				go func() {
-					pingres := ping.RunPinger(config.Interval, statsdClient, groups)
+				go func(group configpkg.TargetGroups) {
+					pingres := ping.RunPinger(config.Interval, statsdClient, group)
 					log.Warn(fmt.Sprintf("Pinger exited: %s", pingres))
 					done <- true
-				}()
+				}(groups)
 			}
 
 			// channel handling for interrupting app

--- a/main.go
+++ b/main.go
@@ -69,8 +69,7 @@ func main() {
 			// everything is fine, let's start pinging!
 			// create a statsdClient
 
-			statsdClient, err := statsd.NewClient(c.String("statsd"), config.Prefix)
-			log.Debug("Global StatsD Prefix: ", config.Prefix)
+			statsdClient, err := statsd.NewClient(c.String("statsd"), "")
 
 			// Issues opening statsd
 			if err != nil {
@@ -86,7 +85,7 @@ func main() {
 			// for each group to ping the targets
 			for _, groups := range config.Groups {
 				go func(group configpkg.TargetGroups) {
-					pingres := ping.RunPinger(config.Interval, statsdClient, group)
+					pingres := ping.RunPinger(config.Interval, config.Prefix, statsdClient, group)
 					log.Warn(fmt.Sprintf("Pinger exited: %s", pingres))
 					done <- true
 				}(groups)


### PR DESCRIPTION
Two bugs - one I introduced, one that was already there.

1) The way I rewrote the loop to generate pinger objects meant that it would end up creating N pinger objects all handling the same target group, rather than handling their own different target groups. That's now fixed.

2) You are meant to be able to a prefix for metrics for each target group. You can define it, but it won't get used - it'll always use the global default - even though the log output indicates otherwise.

Both are fixed by these changes,